### PR TITLE
Alarm.add() should fail if associated data is too big (Closes #2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@ interface <dfn id="alarmmanager">AlarmManager</dfn> {
 <li>If an error occurs, run these substeps and then terminate these steps:
 <ol>
 <li>Set the <code>readyState</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to <code>"done"</code>.
-<li>Set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.
+<li>Set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.
 <li><a class="external" href="http://dom.spec.whatwg.org/#concept-event-fire" title="concept-event-fire">Fire an event</a> named <code>error</code> at the <code><a href="#alarmrequest">AlarmRequest</a></code> object.</li>
 </ol></li>
 <li>When the operation completed successfuly, run these substeps:
@@ -236,9 +236,9 @@ interface <dfn id="alarmmanager">AlarmManager</dfn> {
 <li>If an error occurs, run these substeps and then terminate these steps:
 <ol>
 <li>Set the <code>readyState</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to <code>"done"</code>.
-<li>If the <code>date</code> argument is in the past, then set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to to a <code>DOMError</code> whose name is <code>"InvalidStateError"</code>.</li>
-<li>If the <code>data</code> argument exceeds an implementation-dependent limit, then set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to to a <code>DOMError</code> whose name is <code>"QuotaExceededError"</code>.</li>
-<li>Otherwise, set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.</li>
+<li>If the <code>date</code> argument is in the past, then set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to a <code>DOMError</code> whose name is <code>"InvalidStateError"</code>.</li>
+<li>If the <code>data</code> argument exceeds an implementation-dependent limit, then set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to a <code>DOMError</code> whose name is <code>"QuotaExceededError"</code>.</li>
+<li>Otherwise, set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.</li>
 <li><a class="external" href="http://dom.spec.whatwg.org/#concept-event-fire" title="concept-event-fire">Fire an event</a> named <code>error</code> at the <code><a href="#alarmrequest">AlarmRequest</a></code> object.</li>
 </ol></li>
 <li>When the operation completed successfuly, run these substeps:
@@ -260,7 +260,7 @@ interface <dfn id="alarmmanager">AlarmManager</dfn> {
 <li>If an error occurs, run these substeps and then terminate these steps:
 <ol>
 <li>Set the <code>readyState</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to <code>"done"</code>.
-<li>Set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.
+<li>Set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.
 <li><a class="external" href="http://dom.spec.whatwg.org/#concept-event-fire" title="concept-event-fire">Fire an event</a> named <code>error</code> at the <code><a href="#alarmrequest">AlarmRequest</a></code> object.</li>
 </ol></li>
 <li>When the operation completed successfuly, run these substeps:

--- a/index.html
+++ b/index.html
@@ -236,7 +236,9 @@ interface <dfn id="alarmmanager">AlarmManager</dfn> {
 <li>If an error occurs, run these substeps and then terminate these steps:
 <ol>
 <li>Set the <code>readyState</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to <code>"done"</code>.
-<li>Set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to to a <code>DOMError</code> whose name is <code>"InvalidStateError"</code> if the <code>date</code> argument is in the past, and <code>"UnknownError"</code> otherwise.
+<li>If the <code>date</code> argument is in the past, then set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to to a <code>DOMError</code> whose name is <code>"InvalidStateError"</code>.</li>
+<li>If the <code>data</code> argument exceeds an implementation-dependent limit, then set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to to a <code>DOMError</code> whose name is <code>"QuotaExceededError"</code>.</li>
+<li>Otherwise, set the <code>error</code> attribute of the <code><a href="#alarmrequest">AlarmRequest</a></code> object to to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.</li>
 <li><a class="external" href="http://dom.spec.whatwg.org/#concept-event-fire" title="concept-event-fire">Fire an event</a> named <code>error</code> at the <code><a href="#alarmrequest">AlarmRequest</a></code> object.</li>
 </ol></li>
 <li>When the operation completed successfuly, run these substeps:

--- a/index.src.html
+++ b/index.src.html
@@ -217,7 +217,9 @@ interface <dfn>AlarmManager</dfn> {
 <li>If an error occurs, run these substeps and then terminate these steps:
 <ol>
 <li>Set the <code>readyState</code> attribute of the <code>AlarmRequest</code> object to <code>"done"</code>.
-<li>Set the <code>error</code> attribute of the <code>AlarmRequest</code> object to to a <code>DOMError</code> whose name is <code>"InvalidStateError"</code> if the <code>date</code> argument is in the past, and <code>"UnknownError"</code> otherwise.
+<li>If the <code>date</code> argument is in the past, then set the <code>error</code> attribute of the <code>AlarmRequest</code> object to to a <code>DOMError</code> whose name is <code>"InvalidStateError"</code>.</li>
+<li>If the <code>data</code> argument exceeds an implementation-dependent limit, then set the <code>error</code> attribute of the <code>AlarmRequest</code> object to to a <code>DOMError</code> whose name is <code>"QuotaExceededError"</code>.</li>
+<li>Otherwise, set the <code>error</code> attribute of the <code>AlarmRequest</code> object to to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.</li>
 <li><span data-anolis-spec=dom title=concept-event-fire>Fire an event</span> named <code>error</code> at the <code>AlarmRequest</code> object.</li>
 </ol></li>
 <li>When the operation completed successfuly, run these substeps:

--- a/index.src.html
+++ b/index.src.html
@@ -199,7 +199,7 @@ interface <dfn>AlarmManager</dfn> {
 <li>If an error occurs, run these substeps and then terminate these steps:
 <ol>
 <li>Set the <code>readyState</code> attribute of the <code>AlarmRequest</code> object to <code>"done"</code>.
-<li>Set the <code>error</code> attribute of the <code>AlarmRequest</code> object to to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.
+<li>Set the <code>error</code> attribute of the <code>AlarmRequest</code> object to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.
 <li><span data-anolis-spec=dom title=concept-event-fire>Fire an event</span> named <code>error</code> at the <code>AlarmRequest</code> object.</li>
 </ol></li>
 <li>When the operation completed successfuly, run these substeps:
@@ -217,9 +217,9 @@ interface <dfn>AlarmManager</dfn> {
 <li>If an error occurs, run these substeps and then terminate these steps:
 <ol>
 <li>Set the <code>readyState</code> attribute of the <code>AlarmRequest</code> object to <code>"done"</code>.
-<li>If the <code>date</code> argument is in the past, then set the <code>error</code> attribute of the <code>AlarmRequest</code> object to to a <code>DOMError</code> whose name is <code>"InvalidStateError"</code>.</li>
-<li>If the <code>data</code> argument exceeds an implementation-dependent limit, then set the <code>error</code> attribute of the <code>AlarmRequest</code> object to to a <code>DOMError</code> whose name is <code>"QuotaExceededError"</code>.</li>
-<li>Otherwise, set the <code>error</code> attribute of the <code>AlarmRequest</code> object to to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.</li>
+<li>If the <code>date</code> argument is in the past, then set the <code>error</code> attribute of the <code>AlarmRequest</code> object to a <code>DOMError</code> whose name is <code>"InvalidStateError"</code>.</li>
+<li>If the <code>data</code> argument exceeds an implementation-dependent limit, then set the <code>error</code> attribute of the <code>AlarmRequest</code> object to a <code>DOMError</code> whose name is <code>"QuotaExceededError"</code>.</li>
+<li>Otherwise, set the <code>error</code> attribute of the <code>AlarmRequest</code> object to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.</li>
 <li><span data-anolis-spec=dom title=concept-event-fire>Fire an event</span> named <code>error</code> at the <code>AlarmRequest</code> object.</li>
 </ol></li>
 <li>When the operation completed successfuly, run these substeps:
@@ -241,7 +241,7 @@ interface <dfn>AlarmManager</dfn> {
 <li>If an error occurs, run these substeps and then terminate these steps:
 <ol>
 <li>Set the <code>readyState</code> attribute of the <code>AlarmRequest</code> object to <code>"done"</code>.
-<li>Set the <code>error</code> attribute of the <code>AlarmRequest</code> object to to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.
+<li>Set the <code>error</code> attribute of the <code>AlarmRequest</code> object to a <code>DOMError</code> whose name is <code>"UnknownError"</code>.
 <li><span data-anolis-spec=dom title=concept-event-fire>Fire an event</span> named <code>error</code> at the <code>AlarmRequest</code> object.</li>
 </ol></li>
 <li>When the operation completed successfuly, run these substeps:


### PR DESCRIPTION
Add step to Alarm.add() to fail and set error to "QuotaExceededError"
if the "data" argument exceed an implementation-dependent limit.
