### PR TITLE
Improve specification text referring to DOM Futures (Improves #29)

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@ scheduled time is in the future.
 </li>
 <li>Let <em><a href="#future">future</a></em> be a new <code><a href="#future">Future</a></code> object and <em>resolver</em> its associated resolver.
 </li>
-<li>Return <em><a href="#future">future</a></em>.
+<li>Return <em><a href="#future">future</a></em> and run the remaining steps asynchronously.
 </li>
 <li>If an error occurs, run these substeps and then terminate these steps:
 <ol>
@@ -364,7 +364,7 @@ information of that <a href="#refsECMASCRIPT">[ECMASCRIPT]</a> <code>Date</code>
 <span>Let <em><a href="#future">future</a></em> be a new <code><a href="#future">Future</a></code> object and <em>resolver</em> its associated resolver.</span>
 </li>
 <li>
-<span>Return <em><a href="#future">future</a></em>.</span>
+<span>Return <em><a href="#future">future</a></em> and run the remaining steps asynchronously.</span>
 </li>
 <li>
 <span>If an error occurs, run these substeps and then terminate these steps:</span>
@@ -419,7 +419,7 @@ argument.</span>
 <span>Let <em><a href="#future">future</a></em> be a new <code><a href="#future">Future</a></code> object and <em>resolver</em> its associated resolver.</span>
 </li>
 <li>
-<span>Return <em><a href="#future">future</a></em>.</span>
+<span>Return <em><a href="#future">future</a></em> and run the remaining steps asynchronously.</span>
 </li>
 <li>
 <span>If an error occurs, run these substeps and then terminate these steps:</span>

--- a/index.src.html
+++ b/index.src.html
@@ -301,7 +301,7 @@ scheduled time is in the future.
 </li>
 <li>Let <em>future</em> be a new <code>Future</code> object and <em>resolver</em> its associated resolver.
 </li>
-<li>Return <em>future</em>.
+<li>Return <em>future</em> and run the remaining steps asynchronously.
 </li>
 <li>If an error occurs, run these substeps and then terminate these steps:
 <ol>
@@ -334,7 +334,7 @@ information of that <span data-anolis-ref="">ECMASCRIPT</span> <code>Date</code>
 <span>Let <em>future</em> be a new <code>Future</code> object and <em>resolver</em> its associated resolver.</span>
 </li>
 <li>
-<span>Return <em>future</em>.</span>
+<span>Return <em>future</em> and run the remaining steps asynchronously.</span>
 </li>
 <li>
 <span>If an error occurs, run these substeps and then terminate these steps:</span>
@@ -389,7 +389,7 @@ argument.</span>
 <span>Let <em>future</em> be a new <code>Future</code> object and <em>resolver</em> its associated resolver.</span>
 </li>
 <li>
-<span>Return <em>future</em>.</span>
+<span>Return <em>future</em> and run the remaining steps asynchronously.</span>
 </li>
 <li>
 <span>If an error occurs, run these substeps and then terminate these steps:</span>


### PR DESCRIPTION
Indicate that the remaining steps should be run asynchronously when
returning a future.
