### PR TITLE
Promises are now in EcmaScript 6, not DOM4

### DIFF
--- a/data/references.json
+++ b/data/references.json
@@ -146,6 +146,12 @@
     "title" : "ECMAScript Language Specification",
     "publisher" : "ECMA"
   },
+  "ECMASCRIPT6" :
+  {
+    "href": "https://people.mozilla.org/~jorendorff/es6-draft.html",
+    "title" : "ECMAScript Language Specification (6th edition, draft)",
+    "publisher" : "ECMA"
+  },
   "EDITING" :
   {
     "href" : "http://dvcs.w3.org/hg/editing/raw-file/tip/editing.html",

--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@ Task Scheduler API Specification
 Task Scheduler API Specification
 
 </h1>
-<h2 class="no-num no-toc" id="editor-draft-—-12-november-2013">
-Editor Draft — 12 November 2013
+<h2 class="no-num no-toc" id="editor-draft-—-4-april-2014">
+Editor Draft — 4 April 2014
 </h2>
 <dl>
 <dt>
@@ -87,7 +87,7 @@ Co., Ltd</a></span>, <span class="email"><a href="mailto:ch.dumez@samsung.com">c
 <div class="w3conly">
 
 <!--begin-copyright-->
-<p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2013 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+<p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2014 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
 <!--end-copyright-->
 </div>
 </div>
@@ -220,9 +220,9 @@ The <dfn id="eventhandler"><code><a href="http://dev.w3.org/html5/spec/webappapi
 interface represents a callback used for handling events as defined in <a href="#refsHTML5">[HTML5]</a>.
 </p>
 <p>
-The <dfn id="promise"><code><a href="http://dom.spec.whatwg.org/#promise">Promise</a></code></dfn> interface provides asynchronous
-access to the result of an operation that is ongoing, has yet to start, or has completed, as defined in
-<a href="#refsDOM">[DOM]</a>.
+The <dfn id="promise"><code><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a></code></dfn> interface provides
+asynchronous access to the result of an operation that is ongoing, has yet to start, or has completed, as defined in
+<a href="#refsECMASCRIPT6">[ECMASCRIPT6]</a>.
 </p>
 <p>
 The concepts <dfn id="queue-a-task"><a href="http://dev.w3.org/html5/spec/webappapis.html#queue-a-task">queue a task</a></dfn>,
@@ -456,11 +456,11 @@ References
 <div id="anolis-references"><dl><dt id="refsB2G-ALARM">[B2G-ALARM]
 <dd><cite><a href="https://wiki.mozilla.org/WebAPI/AlarmAPI">B2G Alarm API Specification</a></cite>, Mounir Lamouri, Kan-Ru Chen and Jonas Sicking. Mozilla.
 
-<dt id="refsDOM">[DOM]
-<dd><cite><a href="http://dom.spec.whatwg.org/">DOM</a></cite>, Anne van Kesteren, Aryeh Gregor and Ms2ger. WHATWG.
-
 <dt id="refsECMASCRIPT">[ECMASCRIPT]
 <dd><cite><a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">ECMAScript Language Specification</a></cite>. ECMA.
+
+<dt id="refsECMASCRIPT6">[ECMASCRIPT6]
+<dd><cite><a href="https://people.mozilla.org/~jorendorff/es6-draft.html">ECMAScript Language Specification (6th edition, draft)</a></cite>. ECMA.
 
 <dt id="refsHTML5">[HTML5]
 <dd><cite><a href="http://dev.w3.org/html5/spec/">HTML5</a></cite>, Ian Hickson. W3C.

--- a/index.src.html
+++ b/index.src.html
@@ -192,9 +192,10 @@ The <dfn><code><a href="http://dev.w3.org/html5/spec/webappapis.html#eventhandle
 interface represents a callback used for handling events as defined in <span data-anolis-ref="">HTML5</span>.
 </p>
 <p>
-The <dfn><code><a href="http://dom.spec.whatwg.org/#promise">Promise</a></code></dfn> interface provides asynchronous
-access to the result of an operation that is ongoing, has yet to start, or has completed, as defined in
-<span data-anolis-ref="">DOM</span>.
+The <dfn><code><a href=
+"https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a></code></dfn> interface provides
+asynchronous access to the result of an operation that is ongoing, has yet to start, or has completed, as defined in
+<span data-anolis-ref="">ECMASCRIPT6</span>.
 </p>
 <p>
 The concepts <dfn><a href="http://dev.w3.org/html5/spec/webappapis.html#queue-a-task">queue a task</a></dfn>,


### PR DESCRIPTION
Promises are now in EcmaScript 6, not DOM4. Update the specification
accordingly.
